### PR TITLE
Update underlying template to v0.1.3

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.2
+_commit: v0.1.3
 _src_path: gh:dalito/linkml-project-copier
 copyright_year: '2023'
 create_python_classes: 'Yes'

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -38,7 +38,7 @@ jobs:
           pipx inject poetry poetry-dynamic-versioning
 
       - name: Install dependencies
-        run: poetry install -E docs
+        run: poetry install docs
 
       - name: Build documentation
         run: |

--- a/justfile
+++ b/justfile
@@ -176,13 +176,29 @@ _git-commit:
 _git-status:
     git status
 
+_clean_project:
+    #!{{shebang}}
+    import shutil, pathlib
+    # remove the generated project files
+    for d in pathlib.Path("{{dest}}").iterdir():
+        if d.is_dir():
+            print(f'removing "{d}"')
+            shutil.rmtree(d, ignore_errors=True)
+    # remove the generated python data model
+    for d in pathlib.Path("{{pymodel}}").iterdir():
+        if str(d) == "__init__.py":
+            continue
+        print(f'removing "{d}"')
+        if d.is_dir():
+            shutil.rmtree(d, ignore_errors=True)
+        else:
+            d.unlink()
+
 # Clean all generated files
 [group('project management')]
-clean:
-    rm -rf {{dest}}
+clean: _clean_project
     rm -rf tmp
     rm -rf {{docdir}}/*
-    rm -rf {{pymodel}}
 
 # Private recipes
 _ensure_pymodel_dir:


### PR DESCRIPTION
First update after switching the underlying template to [dalito/linkml-project-copier](https://github.com/dalito/linkml-project-copier). It just works!

The exact command was: `copier update --trust --skip-tasks --skip-answered`

For changes see https://github.com/dalito/linkml-project-copier/releases/tag/v0.1.3