### PR TITLE
Update underlying template to v0.1.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.3
+_commit: v0.1.4
 _src_path: gh:dalito/linkml-project-copier
 copyright_year: '2023'
 create_python_classes: 'Yes'

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -38,7 +38,7 @@ jobs:
           pipx inject poetry poetry-dynamic-versioning
 
       - name: Install dependencies
-        run: poetry install docs
+        run: poetry install
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
v0.1.3 had a bug in the docs-building action that was fixed in linkml-project-copier [Release v0.1.3](https://github.com/dalito/linkml-project-copier/releases/tag/v0.1.3)