### PR TITLE
Update underlying template to v0.1.5

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.4
+_commit: v0.1.5
 _src_path: gh:dalito/linkml-project-copier
 copyright_year: '2023'
 create_python_classes: 'Yes'

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -13,7 +13,7 @@ jobs:
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      contents: write   # to let mkdocs write the new docs
+      contents: write  # to let mkdocs write the new docs
       pages: write     # to deploy to Pages
       id-token: write  # to verify the deployment originates from an appropriate source
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,7 @@
 # Built from:
 # https://docs.github.com/en/actions/guides/building-and-testing-python
 ---
-name: Build & test pid4cat_model
+name: Build and test
 
 on: [pull_request]
 


### PR DESCRIPTION
This PR updates the template to linkml-project-copier [Release v0.1.5](https://github.com/dalito/linkml-project-copier/releases/tag/v0.1.5).

Deploy-docs had a permission problem that was first fixed here before it was fixed in the template. So the fix does not show up in the diff of this PR.

