### PR TITLE
Update underlying template to v0.1.6

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.5
+_commit: v0.1.6
 _src_path: gh:dalito/linkml-project-copier
 copyright_year: '2023'
 create_python_classes: 'Yes'

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -23,6 +23,13 @@ jobs:
         with:
           fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
 
+      - name: Configure git for the bot
+        # Gives the bot that commits to gh-pages a name & email address
+        # so that the commits have an author in the commit log.
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# On Windows the bash shell that comes with Git for Windows should be used.
+# On Windows the "sh" shell that comes with Git for Windows should be used.
 # If it is not on path, give the path to the executable in the following line.
 #set windows-shell := ["C:/Program Files/Git/usr/bin/sh", "-cu"]
 
@@ -170,7 +170,7 @@ _git-add:
 
 # Commit files to git
 _git-commit:
-    git commit -m 'chore: make setup was run' -a
+    git commit -m 'chore: just setup was run' -a
 
 # Show git status
 _git-status:
@@ -186,7 +186,7 @@ _clean_project:
             shutil.rmtree(d, ignore_errors=True)
     # remove the generated python data model
     for d in pathlib.Path("{{pymodel}}").iterdir():
-        if str(d) == "__init__.py":
+        if d.name == "__init__.py":
             continue
         print(f'removing "{d}"')
         if d.is_dir():
@@ -210,4 +210,5 @@ _ensure_docdir:
 _ensure_examples_output:
     -mkdir -p examples/output
 
+# Include project-specific recipes
 import "project.justfile"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1814,7 +1814,7 @@ name = "linkml"
 version = "1.8.5"
 description = "Linked Open Data Modeling Language"
 optional = false
-python-versions = "<4.0.0,>=3.8.1"
+python-versions = ">=3.8.1,<4.0.0"
 groups = ["dev"]
 files = [
     {file = "linkml-1.8.5-py3-none-any.whl", hash = "sha256:5a45577a4bb380f3a128f45764545cb2da92dd3310a110de7dc5355796d5ac43"},
@@ -1877,7 +1877,7 @@ name = "linkml-runtime"
 version = "1.8.3"
 description = "Runtime environment for LinkML, the Linked open data modeling language"
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = ">=3.8,<4.0"
 groups = ["main", "dev"]
 files = [
     {file = "linkml_runtime-1.8.3-py3-none-any.whl", hash = "sha256:0750920f1348fffa903d99e7b5834ce425a2a538285aff9068dbd96d05caabd1"},
@@ -2515,7 +2515,7 @@ name = "prefixmaps"
 version = "0.2.6"
 description = "A python library for retrieving semantic prefix maps"
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = ">=3.8,<4.0"
 groups = ["main", "dev"]
 files = [
     {file = "prefixmaps-0.2.6-py3-none-any.whl", hash = "sha256:f6cef28a7320fc6337cf411be212948ce570333a0ce958940ef684c7fb192a62"},
@@ -2600,7 +2600,7 @@ name = "psutil"
 version = "6.1.1"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 groups = ["dev"]
 files = [
     {file = "psutil-6.1.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:9ccc4316f24409159897799b83004cb1e24f9819b0dcf9c0b68bdcb6cefee6a8"},
@@ -2623,8 +2623,8 @@ files = [
 ]
 
 [package.extras]
-dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest-cov", "requests", "rstcheck", "ruff", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
-test = ["pytest", "pytest-xdist", "setuptools"]
+dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pdbpp", "pylint", "pyperf", "pypinfo", "pyreadline", "pytest-cov", "requests", "rstcheck", "ruff", "sphinx", "sphinx-rtd-theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
+test = ["pytest", "pytest-xdist", "pywin32", "setuptools", "wheel", "wmi"]
 
 [[package]]
 name = "ptyprocess"
@@ -2822,17 +2822,14 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 [[package]]
 name = "pygments"
 version = "2.18.0"
-description = "Pygments is a syntax highlighting package written in Python."
+description = ""
 optional = false
-python-versions = ">=3.8"
+python-versions = "*"
 groups = ["dev"]
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
     {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
 ]
-
-[package.extras]
-windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjsg"
@@ -3144,7 +3141,7 @@ files = [
 [[package]]
 name = "pyyaml-env-tag"
 version = "0.1"
-description = "A custom YAML tag for referencing environment variables in YAML files. "
+description = "A custom YAML tag for referencing environment variables in YAML files."
 optional = false
 python-versions = ">=3.6"
 groups = ["dev"]
@@ -3283,7 +3280,7 @@ name = "rdflib"
 version = "7.1.0"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
 optional = false
-python-versions = "<4.0.0,>=3.8.1"
+python-versions = ">=3.8.1,<4.0.0"
 groups = ["main", "dev"]
 files = [
     {file = "rdflib-7.1.0-py3-none-any.whl", hash = "sha256:240c25c6e1b573ffa67aed23aae128e253c443c15291c9a01d8d392ea80c05b6"},
@@ -3870,7 +3867,7 @@ typing-extensions = ">=4.6.0"
 [package.extras]
 aiomysql = ["aiomysql (>=0.2.0)", "greenlet (!=0.4.17)"]
 aioodbc = ["aioodbc", "greenlet (!=0.4.17)"]
-aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
+aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing-extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
 asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (!=0.4.17)"]
 mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10)"]
@@ -3880,7 +3877,7 @@ mssql-pyodbc = ["pyodbc"]
 mypy = ["mypy (>=0.910)"]
 mysql = ["mysqlclient (>=1.4.0)"]
 mysql-connector = ["mysql-connector-python"]
-oracle = ["cx_oracle (>=8)"]
+oracle = ["cx-oracle (>=8)"]
 oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
 postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
@@ -3890,7 +3887,7 @@ postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
 postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
 pymysql = ["pymysql"]
-sqlcipher = ["sqlcipher3_binary"]
+sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "stack-data"
@@ -3988,7 +3985,7 @@ name = "tornado"
 version = "6.4.2"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">= 3.8"
 groups = ["dev"]
 files = [
     {file = "tornado-6.4.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e828cce1123e9e44ae2a50a9de3055497ab1d0aeb440c5ac23064d9e44880da1"},
@@ -4304,5 +4301,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.11"
-content-hash = "967f9675f1e13b53385027068442aba23197a671ed4b6452b08e39d3e3a223c7"
+python-versions = ">=3.11,<4.0"
+content-hash = "334581ddc867c41f0f19cd691f6950b16807ee313c60bb37f1a004b8aa761b62"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,6 @@ dependencies = [
 requires-poetry = ">=2.0"
 version = "0.0.0"
 
-[tool.poetry.dependencies]
-python = "^3.11"  # see above for why we can't be 3.9 compatible
-linkml-runtime = "^1.1.24"
-
 [tool.poetry.requires-plugins]
 poetry-dynamic-versioning = ">=1.7.0"
 


### PR DESCRIPTION
This PR updates the template to linkml-project-copier [Release v0.1.6](https://github.com/dalito/linkml-project-copier/releases/tag/v0.1.6).