### PR TITLE
Add multiversion docs

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -2,7 +2,15 @@
 name: Deploy docs
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: [main]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions: {}
@@ -48,7 +56,36 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: Build and deploy documentation
+      - name: Generate schema documentation
         run: |
           just gen-doc
-          poetry run mkdocs gh-deploy
+
+      # The if-conditions below make sure to select the right step, depending
+      # on the job trigger. Only one of the steps below will run at a time.
+      # The others will be skipped.
+
+      - name: Check docs in pull requests with strict mode
+        if: github.event_name == 'pull_request'
+        run: |
+          # XXX Enable strict mode once docs are clean
+          echo "Strict check of docs disabled."
+          # poetry run mkdocs build --strict
+
+      # yamllint disable rule:line-length
+      - name: Build & deploy "dev" docs for a new commit to master
+        if: github.event_name == 'push' && github.ref_type != 'tag'
+        run: |
+          export SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          poetry run mike deploy --push --update-aliases --title "dev (${SHORT_SHA})" dev
+
+      - name: Build & deploy docs for a new tag
+        if: github.ref_type == 'tag' && github.event_name == 'push'
+        run: |
+          poetry run mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          poetry run mike set-default latest --push
+
+      - name: Build & deploy docs for a new release
+        if: github.event_name == 'release'
+        run: |
+          poetry run mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          poetry run mike set-default latest --push

--- a/justfile
+++ b/justfile
@@ -66,7 +66,7 @@ update: _update-template _update-linkml
 [group('project management')]
 clean: _clean_project
     rm -rf tmp
-    rm -rf {{docdir}}/*
+    rm -rf {{docdir}}/*.md
 
 # (Re-)Generate project and documentation locally
 [group('model development')]

--- a/poetry.lock
+++ b/poetry.lock
@@ -950,6 +950,50 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.6.1"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e"},
+    {file = "importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580"},
+]
+
+[package.dependencies]
+zipp = ">=3.20"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+perf = ["ipython"]
+test = ["flufl.flake8", "importlib_resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
+type = ["pytest-mypy"]
+
+[[package]]
+name = "importlib-resources"
+version = "6.5.2"
+description = "Read resources from Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
+    {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
+type = ["pytest-mypy"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1776,6 +1820,32 @@ files = [
     {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
     {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
 ]
+
+[[package]]
+name = "mike"
+version = "2.1.3"
+description = "Manage multiple versions of your MkDocs-powered documentation"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "mike-2.1.3-py3-none-any.whl", hash = "sha256:d90c64077e84f06272437b464735130d380703a76a5738b152932884c60c062a"},
+    {file = "mike-2.1.3.tar.gz", hash = "sha256:abd79b8ea483fb0275b7972825d3082e5ae67a41820f8d8a0dc7a3f49944e810"},
+]
+
+[package.dependencies]
+importlib-metadata = "*"
+importlib-resources = "*"
+jinja2 = ">=2.7"
+mkdocs = ">=1.0"
+pyparsing = ">=3.0"
+pyyaml = ">=5.1"
+pyyaml-env-tag = "*"
+verspec = "*"
+
+[package.extras]
+dev = ["coverage", "flake8 (>=3.0)", "flake8-quotes", "shtab"]
+test = ["coverage", "flake8 (>=3.0)", "flake8-quotes", "shtab"]
 
 [[package]]
 name = "mistune"
@@ -3608,6 +3678,21 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "verspec"
+version = "0.1.0"
+description = "Flexible version handling"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31"},
+    {file = "verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e"},
+]
+
+[package.extras]
+test = ["coverage", "flake8 (>=3.7)", "mypy", "pretend", "pytest"]
+
+[[package]]
 name = "watchdog"
 version = "5.0.3"
 description = "Filesystem events monitoring"
@@ -3799,7 +3884,27 @@ files = [
     {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
 ]
 
+[[package]]
+name = "zipp"
+version = "3.21.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
+    {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+type = ["pytest-mypy"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "e6335006ee029e4a10b29166777da8506940699cbe32471aa7ef7e7261528292"
+content-hash = "ae57bdde811dbfaf1d4f23f01540e8575a07834011949644a74ac72edbecea70"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ style = "pep440"
 
 [tool.poetry.group.dev.dependencies]
 linkml = ">=1.3.5"
+mike = ">=2.1.3"
 mkdocs-material = ">=8.2.8"
 mkdocs-mermaid2-plugin = ">=1.1.1"
 jupyter = ">=1.0.0"


### PR DESCRIPTION
I copied the setup that I did for django-components some month ago.

Adding a tag of format "v1.2.3" triggers the creation of a permanent documentation version for this tag.

On merging new contents to main, the dev version of the documentation gets refreshed.