### PR TITLE
Configure mkdocs for mike (multi-version docs)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,10 @@ plugins:
       version: 11.4.1
       # Optionally provide a local copy of mermaid.js (path relative to docs/)
       # javascript: local-js-pkgs/mermaid.min.js
+  - mike:
+    # Multi-version support, https://github.com/jimporter/mike
+    canonical_version: "latest"
+    version_selector: true
 
   # TODO rebuild docs on schema change see
   # https://github.com/dalito/linkml-project-copier/issues/39


### PR DESCRIPTION
In addition to the gh-action changes in #67, this PR configures mkdocs for mike. This enables the version selector and sets "latest" as default.

Closes #43.