### PR TITLE
Renamed slots: url to variant_url & email to email_address

### DIFF
--- a/examples/PID4CatRecord-001.yaml
+++ b/examples/PID4CatRecord-001.yaml
@@ -47,7 +47,7 @@ contains_pids:
           description: Resource description
           resource_category: SAMPLE
           representation_variants:
-          - url: https://example.org/resource
+          - variant_url: https://example.org/resource
             media_type: text/turtle
             encoding_format: UTF-8
             size: 12345

--- a/examples/example_p1.json
+++ b/examples/example_p1.json
@@ -65,7 +65,7 @@
           "resource_category": "SAMPLE",
           "representation_variants": [
             {
-              "url": "https://example.org/resource",
+              "variant_url": "https://example.org/resource",
               "media_type": "text/turtle",
               "encoding_format": "UTF-8",
               "size": 12345
@@ -115,7 +115,7 @@
             "datetime_log": "2024-02-19T00:00:00+00:00",
             "has_agent": {
               "name": "Data Fuzzi",
-              "email": "data.fuzzi@example.org",
+              "email_address": "data.fuzzi@example.org",
               "orcid": "0000-0000-0000-0000",
               "affiliation_ror": "https://ror.org/029hg0311",
               "role": "TRUSTEE"
@@ -127,7 +127,7 @@
             "datetime_log": "2024-05-15T15:51:15+00:00",
             "has_agent": {
               "name": "Data Fuzzi",
-              "email": "data.fuzzi@example.org",
+              "email_address": "data.fuzzi@example.org",
               "orcid": "0000-0000-0000-0000",
               "affiliation_ror": "https://ror.org/029hg0311",
               "role": "TRUSTEE"
@@ -138,6 +138,5 @@
         ]
       }
     }
-  ],
-  "@type": "dict"
+  ]
 }

--- a/examples/example_p1.yaml
+++ b/examples/example_p1.yaml
@@ -48,7 +48,7 @@ contains_pids:
         description: Resource description
         resource_category: SAMPLE
         representation_variants:
-        - url: https://example.org/resource
+        - variant_url: https://example.org/resource
           media_type: text/turtle
           encoding_format: UTF-8
           size: 12345
@@ -81,7 +81,7 @@ contains_pids:
       - datetime_log: 2024-02-19 00:00:00+00:00
         has_agent:
           name: Data Fuzzi
-          email: data.fuzzi@example.org
+          email_address: data.fuzzi@example.org
           orcid: 0000-0000-0000-0000
           affiliation_ror: https://ror.org/029hg0311
           role: TRUSTEE
@@ -90,7 +90,7 @@ contains_pids:
       - datetime_log: 2024-05-15 15:51:15+00:00
         has_agent:
           name: Data Fuzzi
-          email: data.fuzzi@example.org
+          email_address: data.fuzzi@example.org
           orcid: 0000-0000-0000-0000
           affiliation_ror: https://ror.org/029hg0311
           role: TRUSTEE

--- a/examples/example_p1_dataclasses.py
+++ b/examples/example_p1_dataclasses.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 11):
 
 p1_Agent = p4c.Agent(
     name="Data Fuzzi",
-    email="data.fuzzi@example.org",
+    email_address="data.fuzzi@example.org",
     orcid="0000-0000-0000-0000",
     affiliation_ror="https://ror.org/029hg0311",
     role=p4c.Pid4CatAgentRole.TRUSTEE,
@@ -42,7 +42,7 @@ p1_related = [
 
 p1_repr_variants = [
     p4c.RepresentationVariant(
-        url="https://example.org/resource",
+        variant_url="https://example.org/resource",
         media_type="text/turtle",
         encoding_format="UTF-8",
         size=12345,
@@ -170,6 +170,6 @@ container = p4c.HandleRecordContainer(contains_pids=[p1_api])
 # write json to file
 script_folder = Path(__file__).parent
 with open(script_folder / "example_p1.json", "w", encoding="utf-8") as f:
-    f.write(json_dumper.dumps(container))
+    f.write(json_dumper.dumps(container, inject_type=False))
 with open(script_folder / "example_p1.yaml", "w", encoding="utf-8") as f:
     f.write(yaml_dumper.dumps(container))

--- a/examples/example_p1_pydantic.py
+++ b/examples/example_p1_pydantic.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 11):
 
 p1_Agent = p4c.Agent(
     name="Data Fuzzi",
-    email="data.fuzzi@example.org",
+    email_address="data.fuzzi@example.org",
     orcid="0000-0000-0000-0000",
     affiliation_ror="https://ror.org/029hg0311",
     role=p4c.Pid4CatAgentRole.TRUSTEE,
@@ -49,7 +49,7 @@ p1_related = [
 
 p1_repr_variants = [
     p4c.RepresentationVariant(
-        url="https://example.org/resource",
+        variant_url="https://example.org/resource",
         media_type="text/turtle",
         encoding_format="UTF-8",
         size=12345,
@@ -182,7 +182,7 @@ with open(script_folder / "example_p1.yaml", "w", encoding="utf-8") as f:
 try:
     # Next line fails with linkML 1.8.5 due to a bug in json_dumper.py
     # which does not convert datetime objects to strings
-    json_dump = json_dumper.dumps(p1_api)
+    json_dump = json_dumper.dumps(p1_api, inject_type=False)
     print(json_dump)
     # write json to file
     with open(script_folder / "example_p1.json", "w", encoding="utf-8") as f:

--- a/examples/output/README.md
+++ b/examples/output/README.md
@@ -48,7 +48,7 @@ values:
       - encoding_format: UTF-8
         media_type: text/turtle
         size: 12345
-        url: https://example.org/resource
+        variant_url: https://example.org/resource
       resource_category: SAMPLE
   index: 6
   timestamp: '2024-05-15T15:51:15Z'
@@ -81,7 +81,7 @@ values:
       description: 'as requested in issue #123'
       has_agent:
         affiliation_ror: https://ror.org/029hg0311
-        email: datafuzzi@example.org
+        email_address: datafuzzi@example.org
         name: Data Fuzzi
         orcid: 0000-0000-0000-0000
         role: TRUSTEE
@@ -142,7 +142,7 @@ contains_pids:
         - encoding_format: UTF-8
           media_type: text/turtle
           size: 12345
-          url: https://example.org/resource
+          variant_url: https://example.org/resource
         resource_category: SAMPLE
     index: 6
     timestamp: '2024-05-15T15:51:15Z'
@@ -175,7 +175,7 @@ contains_pids:
         description: 'as requested in issue #123'
         has_agent:
           affiliation_ror: https://ror.org/029hg0311
-          email: datafuzzi@example.org
+          email_address: datafuzzi@example.org
           name: Data Fuzzi
           orcid: 0000-0000-0000-0000
           role: TRUSTEE

--- a/nfdi4cat_details.md
+++ b/nfdi4cat_details.md
@@ -118,7 +118,7 @@ from pid4cat_model.datamodel import pid4cat_model_pydantic as p4c
 
 p1_repr_variants = [
     p4c.RepresentationVariant(
-        url="https://example.org/resource",
+        variant_url="https://example.org/resource",
         media_type="text/turtle",
         encoding_format="UTF-8",
         size=12345,

--- a/nfdi4cat_details_ex.py
+++ b/nfdi4cat_details_ex.py
@@ -3,7 +3,7 @@ from pid4cat_model.datamodel import pid4cat_model_pydantic as p4c
 
 p1_repr_variants = [
     p4c.RepresentationVariant(
-        url="https://example.org/resource",
+        variant_url="https://example.org/resource",
         media_type="text/turtle",
         encoding_format="UTF-8",
         size=12345,

--- a/src/pid4cat_model/datamodel/pid4cat_model.py
+++ b/src/pid4cat_model/datamodel/pid4cat_model.py
@@ -1,5 +1,5 @@
 # Auto generated from pid4cat_model.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-03-03T18:55:17
+# Generation date: 2025-03-04T16:21:29
 # Schema: pid4cat-model
 #
 # id: https://w3id.org/nfdi4cat/pid4cat-model
@@ -825,7 +825,7 @@ class Agent(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = PID4CAT_MODEL.Agent
 
     name: str = None
-    email: str = None
+    email_address: str = None
     role: Union[str, "Pid4CatAgentRole"] = None
     orcid: Optional[str] = None
     affiliation_ror: Optional[Union[str, URI]] = None
@@ -836,10 +836,10 @@ class Agent(YAMLRoot):
         if not isinstance(self.name, str):
             self.name = str(self.name)
 
-        if self._is_empty(self.email):
-            self.MissingRequiredField("email")
-        if not isinstance(self.email, str):
-            self.email = str(self.email)
+        if self._is_empty(self.email_address):
+            self.MissingRequiredField("email_address")
+        if not isinstance(self.email_address, str):
+            self.email_address = str(self.email_address)
 
         if self._is_empty(self.role):
             self.MissingRequiredField("role")
@@ -871,14 +871,14 @@ class RepresentationVariant(YAMLRoot):
     class_name: ClassVar[str] = "RepresentationVariant"
     class_model_uri: ClassVar[URIRef] = PID4CAT_MODEL.RepresentationVariant
 
-    url: Optional[Union[str, URI]] = None
+    variant_url: Optional[Union[str, URI]] = None
     media_type: Optional[Union[str, "MEDIATypes"]] = None
     encoding_format: Optional[str] = None
     size: Optional[int] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
-        if self.url is not None and not isinstance(self.url, URI):
-            self.url = URI(self.url)
+        if self.variant_url is not None and not isinstance(self.variant_url, URI):
+            self.variant_url = URI(self.variant_url)
 
         if self.media_type is not None and not isinstance(self.media_type, MEDIATypes):
             self.media_type = MEDIATypes(self.media_type)
@@ -1836,11 +1836,11 @@ slots.name = Slot(
     range=Optional[str],
 )
 
-slots.email = Slot(
-    uri=PID4CAT_MODEL.email,
-    name="email",
-    curie=PID4CAT_MODEL.curie("email"),
-    model_uri=PID4CAT_MODEL.email,
+slots.email_address = Slot(
+    uri=PID4CAT_MODEL.email_address,
+    name="email_address",
+    curie=PID4CAT_MODEL.curie("email_address"),
+    model_uri=PID4CAT_MODEL.email_address,
     domain=None,
     range=Optional[str],
 )
@@ -1899,11 +1899,11 @@ slots.size = Slot(
     range=Optional[int],
 )
 
-slots.url = Slot(
-    uri=PID4CAT_MODEL.url,
-    name="url",
-    curie=PID4CAT_MODEL.curie("url"),
-    model_uri=PID4CAT_MODEL.url,
+slots.variant_url = Slot(
+    uri=PID4CAT_MODEL.variant_url,
+    name="variant_url",
+    curie=PID4CAT_MODEL.curie("variant_url"),
+    model_uri=PID4CAT_MODEL.variant_url,
     domain=None,
     range=Optional[Union[str, URI]],
 )
@@ -2352,11 +2352,11 @@ slots.Agent_name = Slot(
     range=str,
 )
 
-slots.Agent_email = Slot(
-    uri=PID4CAT_MODEL.email,
-    name="Agent_email",
-    curie=PID4CAT_MODEL.curie("email"),
-    model_uri=PID4CAT_MODEL.Agent_email,
+slots.Agent_email_address = Slot(
+    uri=PID4CAT_MODEL.email_address,
+    name="Agent_email_address",
+    curie=PID4CAT_MODEL.curie("email_address"),
+    model_uri=PID4CAT_MODEL.Agent_email_address,
     domain=Agent,
     range=str,
     pattern=re.compile(r"^\S+@[\S+\.]+\S+"),

--- a/src/pid4cat_model/datamodel/pid4cat_model_pydantic.py
+++ b/src/pid4cat_model/datamodel/pid4cat_model_pydantic.py
@@ -1866,8 +1866,8 @@ class Agent(ConfiguredBaseModel):
                     "name": "affiliation_ror",
                     "pattern": "^https:\\/\\/ror\\.org\\/0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$",
                 },
-                "email": {
-                    "name": "email",
+                "email_address": {
+                    "name": "email_address",
                     "pattern": "^\\S+@[\\S+\\.]+\\S+",
                     "required": True,
                 },
@@ -1886,10 +1886,12 @@ class Agent(ConfiguredBaseModel):
         description="""The name of the agent that created or modified the PID record.""",
         json_schema_extra={"linkml_meta": {"alias": "name", "domain_of": ["Agent"]}},
     )
-    email: str = Field(
+    email_address: str = Field(
         ...,
         description="""Email address of the agent that created or modified the PID record.""",
-        json_schema_extra={"linkml_meta": {"alias": "email", "domain_of": ["Agent"]}},
+        json_schema_extra={
+            "linkml_meta": {"alias": "email_address", "domain_of": ["Agent"]}
+        },
     )
     orcid: Optional[str] = Field(
         None,
@@ -1909,16 +1911,16 @@ class Agent(ConfiguredBaseModel):
         json_schema_extra={"linkml_meta": {"alias": "role", "domain_of": ["Agent"]}},
     )
 
-    @field_validator("email")
-    def pattern_email(cls, v):
+    @field_validator("email_address")
+    def pattern_email_address(cls, v):
         pattern = re.compile(r"^\S+@[\S+\.]+\S+")
         if isinstance(v, list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid email format: {element}")
+                    raise ValueError(f"Invalid email_address format: {element}")
         elif isinstance(v, str):
             if not pattern.match(v):
-                raise ValueError(f"Invalid email format: {v}")
+                raise ValueError(f"Invalid email_address format: {v}")
         return v
 
     @field_validator("orcid")
@@ -1958,11 +1960,14 @@ class RepresentationVariant(ConfiguredBaseModel):
         }
     )
 
-    url: Optional[str] = Field(
+    variant_url: Optional[str] = Field(
         None,
-        description="""The URL of the representation.""",
+        description="""The URL of the representation variant.""",
         json_schema_extra={
-            "linkml_meta": {"alias": "url", "domain_of": ["RepresentationVariant"]}
+            "linkml_meta": {
+                "alias": "variant_url",
+                "domain_of": ["RepresentationVariant"],
+            }
         },
     )
     media_type: Optional[MEDIATypes] = Field(

--- a/src/pid4cat_model/schema/pid4cat_model.yaml
+++ b/src/pid4cat_model/schema/pid4cat_model.yaml
@@ -387,14 +387,14 @@ classes:
       curation.
     slots:
       - name
-      - email
+      - email_address
       - orcid
       - affiliation_ror
       - role
     slot_usage:
       name:
         required: true
-      email:
+      email_address:
         pattern: '^\S+@[\S+\.]+\S+'
         required: true
       orcid:
@@ -411,7 +411,7 @@ classes:
       Data class for representations of the resource in other media types than
       text/html which is the default for landing_page_url.
     slots:
-      - url
+      - variant_url
       - media_type
       - encoding_format
       - size
@@ -609,7 +609,7 @@ slots:
   name:
     range: string
     description: The name of the agent that created or modified the PID record.
-  email:
+  email_address:
     range: string
     description: >-
       Email address of the agent that created or modified the PID record.
@@ -638,9 +638,9 @@ slots:
     range: integer
     minimum_value: 0
     description: The size of the representation in bytes.
-  url:
+  variant_url:
     range: uri
-    description: The URL of the representation.
+    description: The URL of the representation variant.
 
   # Slots for RelatedIdentifier
 

--- a/tests/data/valid/HandleAPIRecord-001.yaml
+++ b/tests/data/valid/HandleAPIRecord-001.yaml
@@ -45,7 +45,7 @@ values:
         description: Resource description
         resource_category: SAMPLE
         representation_variants:
-          - url: https://example.org/resource
+          - variant_url: https://example.org/resource
             media_type: text/turtle
             encoding_format: UTF-8
             size: 12345
@@ -78,7 +78,7 @@ values:
         - datetime_log: '2024-02-19T00:00:00Z'
           has_agent:
             name: Data Fuzzi
-            email: datafuzzi@example.org
+            email_address: datafuzzi@example.org
             orcid: 0000-0000-0000-0000
             affiliation_ror: https://ror.org/029hg0311
             role: TRUSTEE

--- a/tests/data/valid/HandleRecordContainer-001.yaml
+++ b/tests/data/valid/HandleRecordContainer-001.yaml
@@ -46,7 +46,7 @@ contains_pids:
             description: Resource description
             resource_category: SAMPLE
             representation_variants:
-              - url: https://example.org/resource
+              - variant_url: https://example.org/resource
                 media_type: text/turtle
                 encoding_format: UTF-8
                 size: 12345
@@ -79,7 +79,7 @@ contains_pids:
             - datetime_log: '2024-02-19T00:00:00Z'
               has_agent:
                 name: Data Fuzzi
-                email: datafuzzi@example.org
+                email_address: datafuzzi@example.org
                 orcid: 0000-0000-0000-0000
                 affiliation_ror: https://ror.org/029hg0311
                 role: TRUSTEE

--- a/tests/data/valid/PID4CatRecord-001.json
+++ b/tests/data/valid/PID4CatRecord-001.json
@@ -66,7 +66,7 @@
                 "resource_category": "SAMPLE",
                 "representation_variants": [
                   {
-                    "url": "https://example.org/resource",
+                    "variant_url": "https://example.org/resource",
                     "media_type": "text/turtle",
                     "encoding_format": "UTF-8",
                     "size": 12345
@@ -91,7 +91,7 @@
                     "datetime_log": "2024-02-19T00:00:00Z",
                     "has_agent": {
                       "name": "Data Fuzzi",
-                      "email": "data.fuzzi@example.org",
+                      "email_address": "data.fuzzi@example.org",
                       "orcid": "0000-0000-0000-0000",
                       "affiliation_ror": "https://ror.org/01abcde",
                       "role": "TRUSTEE"
@@ -103,7 +103,7 @@
                     "datetime_log": "2024-02-19T00:00:00Z",
                     "has_agent": {
                       "name": "Data Fuzzi",
-                      "email": "data.fuzzi@example.org",
+                      "email_address": "data.fuzzi@example.org",
                       "orcid": "0000-0000-0000-0000",
                       "affiliation_ror": "https://ror.org/01abcde",
                       "role": "TRUSTEE"


### PR DESCRIPTION
This fixes the documentation generation with linkml 1.8.6 which is puzzled if slots and class have the same name (although in different case).

Closes #79