### PR TITLE
Revise patterns for handle & doi identifier

### DIFF
--- a/examples/output/README.md
+++ b/examples/output/README.md
@@ -59,7 +59,7 @@ values:
     value:
     - datetime_log: '2024-02-19T00:00:00Z'
       related_identifier:
-        identifier: doi:10.5281/zenodo.8313340
+        identifier: 10.5281/zenodo.8313340
         resolving_url: https://doi.org/10.5281/zenodo.8313340
         type: DoiIdentifier
       relation_type: IS_PART_OF
@@ -153,7 +153,7 @@ contains_pids:
       value:
       - datetime_log: '2024-02-19T00:00:00Z'
         related_identifier:
-          identifier: doi:10.5281/zenodo.8313340
+          identifier: 10.5281/zenodo.8313340
           resolving_url: https://doi.org/10.5281/zenodo.8313340
           type: DoiIdentifier
         relation_type: IS_PART_OF

--- a/src/pid4cat_model/datamodel/pid4cat_model.py
+++ b/src/pid4cat_model/datamodel/pid4cat_model.py
@@ -1,5 +1,5 @@
 # Auto generated from pid4cat_model.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-03-04T16:21:29
+# Generation date: 2025-03-04T17:52:03
 # Schema: pid4cat-model
 #
 # id: https://w3id.org/nfdi4cat/pid4cat-model
@@ -1956,6 +1956,7 @@ slots.HandleAPIRecord_handle = Slot(
     model_uri=PID4CAT_MODEL.HandleAPIRecord_handle,
     domain=HandleAPIRecord,
     range=Union[str, HandleAPIRecordHandle],
+    pattern=re.compile(r"^\d{2}\.T?\d{4,}\/.*$"),
 )
 
 slots.HandleAPIRecord_values = Slot(
@@ -2417,7 +2418,7 @@ slots.DoiIdentifier_identifier = Slot(
     model_uri=PID4CAT_MODEL.DoiIdentifier_identifier,
     domain=DoiIdentifier,
     range=Optional[str],
-    pattern=re.compile(r"^doi:10\.\d{4,}\/.*$"),
+    pattern=re.compile(r"^10\.\d{4,}\/.*$"),
 )
 
 slots.DoiIdentifier_resolving_url = Slot(
@@ -2437,7 +2438,7 @@ slots.HandleIdentifier_identifier = Slot(
     model_uri=PID4CAT_MODEL.HandleIdentifier_identifier,
     domain=HandleIdentifier,
     range=Optional[str],
-    pattern=re.compile(r"^(hdl|handle):\d{2}\.\d{4,}\/.*$"),
+    pattern=re.compile(r"^\d{2}\.T?\d{4,}\/.*$"),
 )
 
 slots.HandleIdentifier_resolving_url = Slot(
@@ -2447,7 +2448,7 @@ slots.HandleIdentifier_resolving_url = Slot(
     model_uri=PID4CAT_MODEL.HandleIdentifier_resolving_url,
     domain=HandleIdentifier,
     range=Union[str, URI],
-    pattern=re.compile(r"^https:\/\/hdl\.handle\.net\/\d{2}\.\d{4,}\/.*$"),
+    pattern=re.compile(r"^https:\/\/hdl\.handle\.net\/\d{2}\.T?\d{4,}\/.*$"),
 )
 
 slots.ArkIdentifier_identifier = Slot(

--- a/src/pid4cat_model/datamodel/pid4cat_model_pydantic.py
+++ b/src/pid4cat_model/datamodel/pid4cat_model_pydantic.py
@@ -307,7 +307,11 @@ class HandleAPIRecord(ConfiguredBaseModel):
         {
             "from_schema": "https://w3id.org/nfdi4cat/pid4cat-model",
             "slot_usage": {
-                "handle": {"name": "handle", "required": True},
+                "handle": {
+                    "name": "handle",
+                    "pattern": "^\\d{2}\\.T?\\d{4,}\\/.*$",
+                    "required": True,
+                },
                 "values": {"name": "values", "required": True},
             },
         }
@@ -338,6 +342,18 @@ class HandleAPIRecord(ConfiguredBaseModel):
             "linkml_meta": {"alias": "values", "domain_of": ["HandleAPIRecord"]}
         },
     )
+
+    @field_validator("handle")
+    def pattern_handle(cls, v):
+        pattern = re.compile(r"^\d{2}\.T?\d{4,}\/.*$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid handle format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid handle format: {v}")
+        return v
 
 
 class HandleRecord(ConfiguredBaseModel):
@@ -2090,10 +2106,7 @@ class DoiIdentifier(RelatedIdentifier):
         {
             "from_schema": "https://w3id.org/nfdi4cat/pid4cat-model",
             "slot_usage": {
-                "identifier": {
-                    "name": "identifier",
-                    "pattern": "^doi:10\\.\\d{4,}\\/.*$",
-                },
+                "identifier": {"name": "identifier", "pattern": "^10\\.\\d{4,}\\/.*$"},
                 "resolving_url": {
                     "name": "resolving_url",
                     "pattern": "^https:\\/\\/doi\\.org\\/10.*$",
@@ -2162,7 +2175,7 @@ class DoiIdentifier(RelatedIdentifier):
 
     @field_validator("identifier")
     def pattern_identifier(cls, v):
-        pattern = re.compile(r"^doi:10\.\d{4,}\/.*$")
+        pattern = re.compile(r"^10\.\d{4,}\/.*$")
         if isinstance(v, list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
@@ -2184,11 +2197,11 @@ class HandleIdentifier(RelatedIdentifier):
             "slot_usage": {
                 "identifier": {
                     "name": "identifier",
-                    "pattern": "^(hdl|handle):\\d{2}\\.\\d{4,}\\/.*$",
+                    "pattern": "^\\d{2}\\.T?\\d{4,}\\/.*$",
                 },
                 "resolving_url": {
                     "name": "resolving_url",
-                    "pattern": "^https:\\/\\/hdl\\.handle\\.net\\/\\d{2}\\.\\d{4,}\\/.*$",
+                    "pattern": "^https:\\/\\/hdl\\.handle\\.net\\/\\d{2}\\.T?\\d{4,}\\/.*$",
                     "required": True,
                 },
             },
@@ -2242,7 +2255,7 @@ class HandleIdentifier(RelatedIdentifier):
 
     @field_validator("resolving_url")
     def pattern_resolving_url(cls, v):
-        pattern = re.compile(r"^https:\/\/hdl\.handle\.net\/\d{2}\.\d{4,}\/.*$")
+        pattern = re.compile(r"^https:\/\/hdl\.handle\.net\/\d{2}\.T?\d{4,}\/.*$")
         if isinstance(v, list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
@@ -2254,7 +2267,7 @@ class HandleIdentifier(RelatedIdentifier):
 
     @field_validator("identifier")
     def pattern_identifier(cls, v):
-        pattern = re.compile(r"^(hdl|handle):\d{2}\.\d{4,}\/.*$")
+        pattern = re.compile(r"^\d{2}\.T?\d{4,}\/.*$")
         if isinstance(v, list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):

--- a/src/pid4cat_model/schema/pid4cat_model.yaml
+++ b/src/pid4cat_model/schema/pid4cat_model.yaml
@@ -56,8 +56,11 @@ classes:
       - values
     slot_usage:
       handle:
-        # to be activated after agreement on handle-suffix patterns
-        # pattern: "^\\d+/\\d+$"
+        # The pattern should be made more restrictive after agreement on the
+        # handle-suffix anatomy. The prefix values should also be checked.
+        # Here is an example for the NFDI4Cat handle servers:
+        # pattern: '(^21\.T11978\/.*$)|(^21\.11165\/.*$)'
+        pattern: '^\d{2}\.T?\d{4,}\/.*$'
         required: true
       values:
         required: true
@@ -452,7 +455,7 @@ classes:
       - identifier
     slot_usage:
       identifier:
-        pattern: '^doi:10\.\d{4,}\/.*$'
+        pattern: '^10\.\d{4,}\/.*$'
       resolving_url:
         pattern: '^https:\/\/doi\.org\/10.*$'
         required: true
@@ -465,10 +468,12 @@ classes:
       - resolving_url
       - identifier
     slot_usage:
+      # The patterns allow test handles like "21.T11978/4cat-demo/3dks-27xc"
+      # In contrast, production handles have only numbers in the prefix.
       identifier:
-        pattern: '^(hdl|handle):\d{2}\.\d{4,}\/.*$'
+        pattern: '^\d{2}\.T?\d{4,}\/.*$'
       resolving_url:
-        pattern: '^https:\/\/hdl\.handle\.net\/\d{2}\.\d{4,}\/.*$'
+        pattern: '^https:\/\/hdl\.handle\.net\/\d{2}\.T?\d{4,}\/.*$'
         required: true
 
   ArkIdentifier:

--- a/tests/data/valid/HandleAPIRecord-001.yaml
+++ b/tests/data/valid/HandleAPIRecord-001.yaml
@@ -59,7 +59,7 @@ values:
         - relation_type: IS_PART_OF
           related_identifier:
             type: DoiIdentifier
-            identifier: 'doi:10.5281/zenodo.8313340'
+            identifier: '10.5281/zenodo.8313340'
             resolving_url: https://doi.org/10.5281/zenodo.8313340
           datetime_log: '2024-02-19T00:00:00Z'
         - relation_type: IS_REFERENCED_BY

--- a/tests/data/valid/HandleRecordContainer-001.yaml
+++ b/tests/data/valid/HandleRecordContainer-001.yaml
@@ -60,7 +60,7 @@ contains_pids:
             - relation_type: IS_PART_OF
               related_identifier:
                 type: DoiIdentifier
-                identifier: 'doi:10.5281/zenodo.8313340'
+                identifier: '10.5281/zenodo.8313340'
                 resolving_url: https://doi.org/10.5281/zenodo.8313340
               datetime_log: '2024-02-19T00:00:00Z'
             - relation_type: IS_REFERENCED_BY


### PR DESCRIPTION
Changes the pattern for how the non-url form of DOIs and handles are stored (slot: identifier):

- Old: `doi:10.5281/zenodo.8313340`
- New: `10.5281/zenodo.8313340`

Closes #80