### PR TITLE
Add build of dynamic-versioned, merged schema

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Generate schema documentation
         run: |
+          # inject the version into the schema
+          poetry dynamic-versioning
           just gen-doc
 
       # The if-conditions below make sure to select the right step, depending

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
-/docs/local-js-pkgs
+docs/local-js-pkgs
 
 # generated part of documentation
-/docs/elements/*.md
+docs/elements/*.md
+
+# generated merged schema
+docs/schema/*
+!docs/schema/README.md
 
 # linkml-run-examples output (not useful to have in git in its current form)
-/examples/output/
+examples/output/
 
 # Derived schemas, generated from the schema.yaml
 tmp/

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,8 @@
+# Merged model
+
+This folder contains the fully resolved pid4cat model, including all imported models.
+The files are auto-generated from the schema in the `src/pid4cat_model/schema` folder and version-stamped by poetry-dynamic-versioning.
+For releases, these files are copied to gh-pages along with the rest of the documentation, making schema files with version information available on gh-pages.
+The w3id.org redirects link to these files.
+
+Note, that the generated files are git-ignored.

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ dest := "project"
 pymodel := src / schema_name / "datamodel"
 source_schema_path := source_schema_dir / schema_name + ".yaml"
 docdir := "docs/elements"  # Directory for generated documentation
+merged_schema_path := "docs/schema" / schema_name + ".yaml"
 
 # ============== Project recipes ==============
 
@@ -80,7 +81,7 @@ site: gen-project gen-doc
 # Deploy documentation site to Github Pages
 [group('deployment')]
 deploy: site
-  mkd-gh-deploy
+    mkd-gh-deploy
 
 # Run all tests
 [group('model development')]
@@ -89,12 +90,12 @@ test: _test-schema _test-python _test-examples
 # Run linting
 [group('model development')]
 lint:
-    poetry run linkml-lint {{source_schema_dir}}
+  poetry run linkml-lint {{source_schema_dir}}
 
 # Generate md documentation for the schema
 [group('model development')]
-gen-doc:
-    poetry run gen-doc {{gen_doc_args}} -d {{docdir}} {{source_schema_path}}
+gen-doc: _gen-yaml
+  poetry run gen-doc {{gen_doc_args}} -d {{docdir}} {{source_schema_path}}
 
 # Build docs and run test server
 [group('model development')]
@@ -193,6 +194,10 @@ _test-examples: _ensure_examples_output
         --input-directory tests/data/valid \
         --output-directory examples/output \
         --schema {{source_schema_path}} > examples/output/README.md
+
+# Generate merged model
+_gen-yaml:
+  poetry run gen-yaml {{source_schema_path}} > {{merged_schema_path}}
 
 # Run documentation server
 _serve:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = ["README.md", "src/pid4cat_model/schema", "project"]
 # We can't use caret ^ requirement specifiers here. They are a Poetry speciality.
 requires-python = ">=3.11,<4.0"  # due to linkml-runtime bug, https://github.com/linkml/linkml-runtime/pull/357
 
-dynamic = ["version"]
+dynamic = []
 
 dependencies = [
   "linkml-runtime >=1.8.0",
@@ -28,9 +28,9 @@ dependencies = [
 
 # Ref.: https://python-poetry.org/docs/
 # Ref.: https://github.com/mtkennerly/poetry-dynamic-versioning
+version = "0.2.0"
 [tool.poetry]
 requires-poetry = ">=2.0"
-version = "0.0.0"
 
 [tool.poetry.requires-plugins]
 poetry-dynamic-versioning = ">=1.7.0"
@@ -39,6 +39,16 @@ poetry-dynamic-versioning = ">=1.7.0"
 enable = true
 vcs = "git"
 style = "pep440"
+
+# Setup injection of the version specifier into the schema file
+[tool.poetry-dynamic-versioning.substitution]
+files =  ["pid4cat_model.yaml"]
+folders = [
+  { path = "src/pid4cat_model/schema" }
+]
+patterns = [
+  """(^version\\s*(?::.*?)?:\\s*['"])[^'"]*(['"]\\s*# Managed by dynamic-versioning.)""",
+]
 
 [tool.poetry.group.dev.dependencies]
 linkml = ">=1.3.5"

--- a/src/pid4cat_model/schema/pid4cat_model.yaml
+++ b/src/pid4cat_model/schema/pid4cat_model.yaml
@@ -14,6 +14,8 @@ description: >-
   exception of the resource category, which is a high-level description of
   what is identified by the pid4cat handle, e.g. a sample or a device.
 
+version: "0.0.0"  # Managed by dynamic-versioning. Don't change this line!
+
 todos:
   - none
 


### PR DESCRIPTION
The merged schema will be deployed with the documentation. The version is injected by poetry-dynamic-versioning as part of the documentation deployment (`deploy-docs.yaml`).

Closes #84 