### PR TITLE
Run deploy-docs & pypi-publish also on rc-version-tags

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -4,6 +4,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]'
     branches:
       - main
   pull_request:

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -14,6 +14,7 @@ on:  # yamllint disable-line rule:truthy
       # GitHub glob matching is limited [1]. So we can't define a pattern matching
       # pep 440 version definition [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
       - 'v[0-9]+.[0-9]+.[0-9]+.?*'
+      - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]'
   release:
     types: [published]
 


### PR DESCRIPTION
This adds a second trigger-pattern `v[0-9]+.[0-9]+.[0-9]+rc[0-9]` for releasing the documentation or the Python package to run the actions also for a release candidate tags like `v1.0.0rc1`.

Closes #86