### PR TITLE
Update main README / add package README for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI - main](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml/badge.svg)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml)
 [![CI - docs](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml/badge.svg?branch=main)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml)
 [![DOI](https://zenodo.org/badge/598213054.svg)](https://zenodo.org/badge/latestdoi/598213054)
-[![PyPI - Version](https://img.shields.io/pypi/v/pid4cat)](https://pypi.org/project/pid4cat)
+[![PyPI - Version](https://img.shields.io/pypi/v/pid4cat-model)](https://pypi.org/project/pid4cat-model)
 
 # Persistent Identifiers for FAIR data in Catalysis
 
@@ -15,7 +15,7 @@ This repository contains
 
 - **pid4cat service** documentation
 - **pid4cat model** expressed as a [LinkML](https://linkml.io/) model.
-- **pid4cat Python package** to interface the pid4cat service and handle the PID metadata
+- **pid4cat-model Python package** to interface the pid4cat service and handle the PID metadata
 
 The PID metadata model and tools are generic and may be useful beyond catalysis.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![CI - main](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml/badge.svg)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml)
 [![CI - docs](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml/badge.svg?branch=main)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml)
+[![DOI](https://zenodo.org/badge/598213054.svg)](https://zenodo.org/badge/latestdoi/598213054)
+[![PyPI - Version](https://img.shields.io/pypi/v/pid4cat)](https://pypi.org/project/pid4cat)
 
 # Persistent Identifiers for FAIR data in Catalysis
 
@@ -7,9 +9,15 @@
 
 **pid4cat** is NFDI4Cat´s service for metadata rich, universal persistent identifiers. pid4cat builds upon the handle-system (as DOIs do). pid4cat adds a **custom API** to a handle server and provides a **LinkML model for  PID-related metadata**. The metadata are stored in the handle records. **pid4cat**  persistent identifiers are used for samples, devices, and more, to ensure consistent tracking, integration, and accessibility of resources across both central and local RDM systems.
 
-## pid4cat metadata model
+## Components of pid4cat
 
-This repository contains the **pid4cat service** documentation and the **pid4cat model** expressed as a [LinkML](https://linkml.io/) model. The model is a generic PID metadata model that may be useful beyond catalysis.
+This repository contains
+
+- **pid4cat service** documentation
+- **pid4cat model** expressed as a [LinkML](https://linkml.io/) model.
+- **pid4cat Python package** to interface the pid4cat service and handle the PID metadata
+
+The PID metadata model and tools are generic and may be useful beyond catalysis.
 
 > Status: beta - This is in development and may still change.
 > We are interested in feedback of potential users.
@@ -19,7 +27,7 @@ This repository contains the **pid4cat service** documentation and the **pid4cat
 
 - [pid4cat](https://nfdi4cat.github.io/pid4cat-model) documentation
 - [pid4cat-model](https://nfdi4cat.github.io/pid4cat-model/latest/elements/) metadata schema documentation
-- [NFDI4Cat PID concept](nfdi4cat_details.md) - (older) information about the role and use of this model in NFDI4Cat.
+- [pid4cat Python package](https://nfdi4cat.github.io/pid4cat-model/latest/tools/) metadata schema documentation
 
 ## Repository Structure
 
@@ -31,6 +39,7 @@ This repository contains the **pid4cat service** documentation and the **pid4cat
   - [pid4cat_model](src/pid4cat_model)
     - [schema](src/pid4cat_model/schema) -- LinkML schema
     - [datamodel](src/pid4cat_model/datamodel) -- generated Python data models
+    - other modules included in Python package
 - [tests/](tests/) - Python tests
   - [data/](tests/data) - Example data
 
@@ -52,7 +61,7 @@ In addition to the [GitHub contributors](https://github.com/nfdi4cat/pid4cat-mod
 
 Main author:
 
-- David Linke (ORCID: [0000-0002-5898-1820](https://orcid.org/0000-0002-5898-1820)) - Idea, initial setup of repository, main developer of pid4cat-model, project coordination.
+- David Linke (ORCID: [0000-0002-5898-1820](https://orcid.org/0000-0002-5898-1820)) - Idea, initial setup of repository, main developer of pid4cat-model and Python package, project coordination.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The PID metadata model and tools are generic and may be useful beyond catalysis.
 
 - [pid4cat](https://nfdi4cat.github.io/pid4cat-model) documentation
 - [pid4cat-model](https://nfdi4cat.github.io/pid4cat-model/latest/elements/) metadata schema documentation
-- [pid4cat Python package](https://nfdi4cat.github.io/pid4cat-model/latest/tools/) metadata schema documentation
+- [pid4cat Python package](https://nfdi4cat.github.io/pid4cat-model/latest/tools/) metadata schema documentation, see also [README_pypkg](/README_pypkg.md)
 
 ## Repository Structure
 

--- a/README_pypkg.md
+++ b/README_pypkg.md
@@ -10,7 +10,15 @@ pid4cat builds upon the handle-system (as DOIs do). pid4cat adds a **custom API*
 The metadata are stored in the handle records.
 
 This Python package includes an equivalent Python (pydantic) model of the LinkML-based datamodel for the metadata of pid4cat identifiers.
-It moreover includes some helpers to make simplify using the pid4cat identifiers.
+It moreover includes some helpers to simplify using pid4cat identifiers.
+
+## Installation
+
+The pid4cat Python is [published on PyPI](https://pypi.org/project/pid4cat) and can be installed in the usual  way
+
+```bash
+pip install pid4cat
+```
 
 ## Documentation
 

--- a/README_pypkg.md
+++ b/README_pypkg.md
@@ -1,0 +1,31 @@
+[![CI - main](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml/badge.svg)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml)
+[![CI - docs](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml/badge.svg?branch=main)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml)
+[![PyPI - Version](https://img.shields.io/pypi/v/pid4cat)](https://pypi.org/project/pid4cat)
+[![DOI](https://zenodo.org/badge/598213054.svg)](https://zenodo.org/badge/latestdoi/598213054)
+
+# Python package for pid4cat persistent identifiers
+
+The package helps to interface the **pid4cat service**, a service offered by NFDI4Cat for metadata rich, universal persistent identifiers.
+pid4cat builds upon the handle-system (as DOIs do). pid4cat adds a **custom API** to a handle server and provides a **LinkML model for  PID-related metadata**.
+The metadata are stored in the handle records.
+
+This Python package includes an equivalent Python (pydantic) model of the LinkML-based datamodel for the metadata of pid4cat identifiers.
+It moreover includes some helpers to make simplify using the pid4cat identifiers.
+
+## Documentation
+
+- [pid4cat Python package](https://nfdi4cat.github.io/pid4cat-model/latest/tools/) metadata schema documentation
+
+## Contributors
+
+See main [README](https://github.com/nfdi4cat/pid4cat-model/blob/main/README.md).
+
+## License
+
+The pid4cat Python package is distributed under the MIT license.
+
+## Acknowledgement
+
+This project started as an in-kind contribution of [Leibniz-Institut für Katalyse e.V.](https://www.catalysis.de) (Rostock, Germany) to the NFDI4Cat project.
+
+After 2024-03-27 this work has been funded by the German Research Foundation (DFG) through the project "[NFDI4Cat](https://www.nfdi4cat.org) - NFDI for Catalysis-Related Sciences" (DFG project no. [441926934](https://gepris.dfg.de/gepris/projekt/441926934)), within the National Research Data Infrastructure ([NFDI](https://www.nfdi.de)) programme of the Joint Science Conference (GWK).

--- a/README_pypkg.md
+++ b/README_pypkg.md
@@ -1,6 +1,6 @@
 [![CI - main](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml/badge.svg)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/main.yaml)
 [![CI - docs](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml/badge.svg?branch=main)](https://github.com/nfdi4cat/pid4cat-model/actions/workflows/deploy-docs.yaml)
-[![PyPI - Version](https://img.shields.io/pypi/v/pid4cat)](https://pypi.org/project/pid4cat)
+[![PyPI - Version](https://img.shields.io/pypi/v/pid4cat-model)](https://pypi.org/project/pid4cat-model)
 [![DOI](https://zenodo.org/badge/598213054.svg)](https://zenodo.org/badge/latestdoi/598213054)
 
 # Python package for pid4cat persistent identifiers
@@ -17,7 +17,7 @@ It moreover includes some helpers to simplify using pid4cat identifiers.
 The pid4cat Python is [published on PyPI](https://pypi.org/project/pid4cat) and can be installed in the usual  way
 
 ```bash
-pip install pid4cat
+pip install pid4cat-model
 ```
 
 ## Documentation

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples of using pid4cat-model
 
-This folder some examples python scripts and jupyter notebooks.
+This folder contains some example data and scripts (Python & jupyter notebooks).
 There are examples for using the data model as well as for making API requests.
 
 The JSON and YAML files in this directory were created by running the example scripts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
-name = "pid4cat_model"
-description = "LinkML model for handle-based PIDs for resources in catalysis (pid4cat)"
+name = "pid4cat"
+description = "Python model equivalent of LinkML datamodel for handle-based PIDs for resources in catalysis (pid4cat)"
 authors = [
   # Authors sorted by number of commits
   {name = "David Linke", email = "david.linke@catalysis.de"},
@@ -14,7 +14,7 @@ maintainers = [
 ]
 license = "MIT"
 license-files = ["LICENSE"]
-readme = "README.md"
+readme = "README_pypkg.md"
 requires-python = ">=3.11,<4.0"
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
-name = "pid4cat"
+name = "pid4cat-model"
 description = "Python model equivalent of LinkML datamodel for handle-based PIDs for resources in catalysis (pid4cat)"
 authors = [
   # Authors sorted by number of commits

--- a/uv.lock
+++ b/uv.lock
@@ -1520,7 +1520,7 @@ wheels = [
 ]
 
 [[package]]
-name = "pid4cat"
+name = "pid4cat-model"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1520,7 +1520,7 @@ wheels = [
 ]
 
 [[package]]
-name = "pid4cat-model"
+name = "pid4cat"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This adds a reduced readme for PyPI (`README_pypkg.md`) and renames the package in `pyproject.toml` from "pid4cat_model" to "pid4cat-model".

Prepares for #111