### PR TITLE
Switch docs to use subfolder-type-separation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 docs/local-js-pkgs
 
 # generated part of documentation
-docs/elements/*.md
+docs/elements/**/*.md
 
 # generated merged schema
 docs/schema/*

--- a/config.public.mk
+++ b/config.public.mk
@@ -17,10 +17,7 @@ LINKML_SCHEMA_SOURCE_DIR="src/pid4cat_model/schema"
 LINKML_GENERATORS_CONFIG_YAML=config.yaml
 
 ## pass args if gendoc ignores config.yaml (i.e. --no-mergeimports)
-# It would be nice to separate the docs by type via "--subfolder-type-separation"
-#   but the URIs of classes and slots are not adapted and therefore not
-#   suitable for redirecting via w3id.org. linkml#2561
-LINKML_GENERATORS_DOC_ARGS="--hierarchical-class-view --index-name overview"
+LINKML_GENERATORS_DOC_ARGS="--hierarchical-class-view --subfolder-type-separation --index-name overview"
 
 ## pass args to workaround genowl rdfs config bug (linkml#1453)
 ##   (i.e. --no-type-objects --no-metaclasses --metadata-profile rdfs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,11 @@ markdown_extensions:
   - admonition
   - footnotes
   - pymdownx.details
-  - pymdownx.superfences
-
+  - pymdownx.superfences:
+      # make exceptions to highlighting of code:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid_custom
 exclude_docs: |
   /templates-linkml/


### PR DESCRIPTION
Related to #69 - This option splits the markdown schema documentation pages are split to separate folders by element type (classes/slots/enums/types) and enables creating element URIs that are compatible with w3id.org redirects.
However, the URIs will only be correct after the next linkml-release which contains a fix for the URI generation with this option.

The PR also fixes the rendering of mermaid class diagrams (which are currently shown as ascii).
