### PR TITLE
Add iso7064 checksum module

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -127,8 +127,8 @@ Suggested checksum calculations:
   Hence, it is well suited to detect error in alphanumeric identification numbers.
   This algorithm is for example used by the [Global Release Identifier](https://en.wikipedia.org/wiki/Global_Release_Identifier).
 
-Implementation of these algorithms are available in many languages (for example in [python-stdnum](https://arthurdejong.org/python-stdnum/doc/1.20/stdnum.iso7064),
-[base32-lib](https://pypi.org/project/base32-lib/) for Python or [cdigit](https://github.com/LiosK/cdigit) for JavaScript).
+Implementation of these algorithms are available in many languages (for example in [python-stdnum](https://arthurdejong.org/python-stdnum/doc/1.20/stdnum.iso7064).The [base32-lib](https://pypi.org/project/base32-lib/) for Python or [cdigit](https://github.com/LiosK/cdigit) for JavaScript).
+We have also added many ISO 7064 checksum algorithms to the [pid4cat-model](https://pypi.org/project/pid4cat-model/) Python package.
 
 !!! warning "Open question on supporting case sensitivity for identifier suffix."
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,6 +6,26 @@
 
 - interacting with the pid4cat API to create, read and update pid4cat identifiers and their metadata.
 - validating pid4cat metadata against the pid4cat-model schema.
+- calculating and validating ISO 7064 checksums which may be used in local identifier schemes.
+
+[ISO/IEC 7064](https://www.iso.org/standard/31531.html) describes eight generic check digit (character) systems for numeric, alphabetic, and alphanumeric strings.
+It specifies two types of systems that use the same algorithm with different parameters:
+Pure systems and Hybrid systems.
+
+| Algorithm               | Function name | Input string          | Check character(s)                  |
+| ------------------------- | ----------- | --------------------- | ----------------------------------- |
+| ***Pure***                |             |                       |                                     |
+| ISO/IEC 7064, MOD 11-2    | mod11_2     | Numeric (0-9)         | 1 digit or 'X' (0-9X)               |
+| ISO/IEC 7064, MOD 37-2    | mod37_2     | Alphanumeric (0-9A-Z) | 1 digit, letter, or '\*' (0-9A-Z\*) |
+| ISO/IEC 7064, MOD 97-10   | mod97_10    | Numeric (0-9)         | 2 digits (0-9)                      |
+| ISO/IEC 7064, MOD 661-26  | mod661_26   | Alphabetic (A-Z)      | 2 letters (A-Z)                     |
+| ISO/IEC 7064, MOD 1271-36 | mod1271_36  | Alphanumeric (0-9A-Z) | 2 digits or letters (0-9A-Z)        |
+| ***Hybrid***              |             |                       |                                     |
+| ISO/IEC 7064, MOD 11,10   | mod11_10    | Numeric (0-9)         | 1 digit (0-9)                       |
+| ISO/IEC 7064, MOD 27,26   | mod27_26    | Alphabetic (A-Z)      | 1 letter (A-Z)                      |
+| ISO/IEC 7064, MOD 37,36   | mod37_36    | Alphanumeric (0-9A-Z) | 1 digit or letter (0-9A-Z)          |
+
+The pid4cat_model.iso7064 module contains implementations of all algorithms in the table.
 
 ## pid4cat API
 

--- a/project.justfile
+++ b/project.justfile
@@ -1,1 +1,7 @@
 ## Add your own just recipes here. This is imported by the main justfile.
+
+# Run Python tests and report test coverage
+[group('special pid4cat-model')]
+coverage:
+  uv run python -m coverage run -m pytest
+  uv run python -m coverage html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dev = [
     "mkdocs-mermaid2-plugin>=1.1.1",
     "jupyter>=1.0.0",
     "mknotebooks>= 0.8.0",
+    "pytest>=8.3.5",
+    "coverage>=7.8.0",
 ]
 
 # See https://hatch.pypa.io/latest/config/build/#file-selection for how to
@@ -55,6 +57,34 @@ fallback-version = "0.0.0"
 # Ref.: https://docs.pytest.org/en/stable/reference/reference.html#configuration-options
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+# https://coverage.readthedocs.io/en/latest/config.html
+[tool.coverage.paths]
+# Specify where coverage schould look for source files.
+source = [
+    "src",
+    # "**/site-packages", # for not using tox
+    # ".tox/**/site-packages",
+]
+
+[tool.coverage.report]
+# Show in report which lines are not covered
+show_missing = false
+# Any line of the source code that matches one of these regexes is excluded
+# from being reported as missing.
+exclude_lines = [
+    # Have to re-enable the standard pragma
+    "pragma: no cover",
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "return NotImplemented",
+    "if __name__ == .__main__.:",
+]
+
+[tool.coverage.html]
+# Directory where to write the HTML report files.
+directory = ".htmlcov"
 
 # Ref.: https://github.com/codespell-project/codespell
 [tool.codespell]

--- a/src/pid4cat_model/iso7064.py
+++ b/src/pid4cat_model/iso7064.py
@@ -1,0 +1,287 @@
+"""
+ISO/IEC 7064 Checksum Algorithms Implementation in Python
+
+This module implements the eight generic check digit (character) systems for
+numeric, alphabetic, and alphanumeric strings. ISO/IEC 7064 specifies two
+types of systems that use the same algorithm with different parameters:
+Pure systems (MOD 11-2, MOD 37-2, MOD 97-10, MOD 661-26, and MOD 1271-36)
+and Hybrid systems (MOD 11,10, MOD 27,26, and MOD 37,36).
+
+Author: David Linke, adapted from cdigit implementation
+License: MIT
+
+Inspired by JavaScript package: https://github.com/LiosK/cdigit (License: MIT)
+"""
+
+from typing import List, Tuple
+
+
+class ISO7064Pure:
+    """
+    Implements the ISO 7064 pure system recursive method.
+    """
+
+    def __init__(self, mod: int, radix: int, alphabet: str, flavor: str) -> None:
+        """
+        Initialize the ISO 7064 pure system.
+
+        Args:
+            name (str): Short name of the algorithm.
+            long_name (str): Full name of the algorithm.
+            mod (int): Modulus used in the algorithm.
+            radix (int): Radix (base) of the number system.
+            alphabet (str): Character set used in the algorithm.
+            flavor (str): Type of the algorithm ("EXTRA_CHAR" or "TWO_CCS").
+        """
+        self.name: str = f"mod_{mod}_{radix}"
+        self.long_name: str = f"ISO/IEC 7064, MOD {int}-{radix}"
+        self.mod: int = mod
+        self.radix: int = radix
+        self.alphabet: str = alphabet
+        self.flavor: str = flavor  # "EXTRA_CHAR" or "TWO_CCS"
+
+    def compute_from_num_vals(self, ns: List[int]) -> List[int]:
+        """
+        Compute the check character(s) from numerical values.
+
+        Args:
+            ns (list[int]): List of numerical values representing the input string.
+
+        Returns:
+            list[int]: List of numerical values representing the check character(s).
+
+        Raises:
+            ValueError: If the input is empty or contains invalid values.
+        """
+        max_num_val = (
+            len(self.alphabet) - 1
+            if self.flavor == "EXTRA_CHAR"
+            else len(self.alphabet)
+        )
+        if not ns:
+            raise ValueError("String to be protected is empty")
+        if any(e < 0 or e >= max_num_val or not isinstance(e, int) for e in ns):
+            raise ValueError("Invalid numerical value detected")
+
+        c = 0
+        for e in ns + [0, 0] if self.flavor == "TWO_CCS" else ns + [0]:
+            if c > 0xFFF_FFFF_FFFF:  # ~2^44 at max
+                c %= self.mod
+            c = c * self.radix + e
+        c = (self.mod + 1 - (c % self.mod)) % self.mod
+
+        if self.flavor == "TWO_CCS":
+            return [c // self.radix, c % self.radix]
+        return [c]
+
+    def compute(self, s: str) -> str:
+        """
+        Compute the check character(s) for the given string.
+
+        Args:
+            s (str): Input string without check characters.
+
+        Returns:
+            str: Check character(s) computed from the input string.
+        """
+        char_map = {
+            c: i
+            for i, c in enumerate(
+                self.alphabet[:-1] if self.flavor == "EXTRA_CHAR" else self.alphabet
+            )
+        }
+        ns = [char_map[c] for c in s if c in char_map]
+
+        cc = self.compute_from_num_vals(ns)
+        if self.flavor == "TWO_CCS":
+            return self.alphabet[cc[0]] + self.alphabet[cc[1]]
+        return self.alphabet[cc[0]]
+
+    def parse(self, s: str) -> Tuple[str, str]:
+        """
+        Parse the input string into the bare string and check character(s).
+
+        Args:
+            s (str): Input string with check characters.
+
+        Returns:
+            tuple[str, str]: Bare string and check character(s).
+
+        Raises:
+            ValueError: If the check character(s) cannot be found.
+        """
+        char_map = {c: i for i, c in enumerate(self.alphabet)}
+        n = 2 if self.flavor == "TWO_CCS" else 1
+        cc = s[-n:]
+        if len(cc) == n and all(c in char_map for c in cc):
+            return s[:-n], cc
+        raise ValueError("Could not find check character(s)")
+
+    def generate(self, s: str) -> str:
+        """
+        Generate a protected string by appending check character(s).
+
+        Args:
+            s (str): Input string without check characters.
+
+        Returns:
+            str: Protected string with appended check character(s).
+        """
+        return f"{s}{self.compute(s)}"
+
+    def validate(self, s: str) -> bool:
+        """
+        Validate the input string with check character(s).
+
+        Args:
+            s (str): Input string with check characters.
+
+        Returns:
+            bool: True if the string is valid, False otherwise.
+        """
+        bare, cc = self.parse(s)
+        return self.compute(bare) == cc
+
+
+class ISO7064Hybrid:
+    """
+    Implements the ISO 7064 hybrid system recursive method.
+    """
+
+    def __init__(self, alphabet: str) -> None:
+        """
+        Initialize the ISO 7064 hybrid system.
+
+        Args:
+            alphabet (str): Character set used in the algorithm.
+        """
+        self.alphabet: str = alphabet
+        self.mod = len(self.alphabet)
+        self.char_map = {c: i for i, c in enumerate(self.alphabet)}
+        radix = self.mod - 1
+        self.name: str = f"mod_{self.mod}_{radix}"
+        self.long_name: str = f"ISO/IEC 7064, MOD {int}-{radix}"
+
+    def compute_from_num_vals(self, ns: List[int]) -> List[int]:
+        """
+        Compute the check character(s) from numerical values.
+
+        Args:
+            ns (list[int]): List of numerical values representing the input string.
+
+        Returns:
+            list[int]: List of numerical values representing the check character(s).
+
+        Raises:
+            ValueError: If the input is empty or contains invalid values.
+        """
+        mod = len(self.alphabet)
+        if not ns:
+            raise ValueError("String to be protected is empty")
+        if any(e < 0 or e >= mod or not isinstance(e, int) for e in ns):
+            raise ValueError("Invalid numerical value detected")
+
+        c = mod
+        for e in ns:
+            c = (c % (mod + 1)) + e
+            c = (c % mod or mod) * 2
+        c %= mod + 1
+
+        return [(mod + 1 - c) % mod]
+
+    def compute(self, s: str) -> str:
+        """
+        Compute the check character(s) for the given string.
+
+        Args:
+            s (str): Input string without check characters.
+
+        Returns:
+            str: Check character(s) computed from the input string.
+        """
+        ns = [self.char_map[c] for c in s if c in self.char_map]
+
+        cc = self.compute_from_num_vals(ns)
+        return self.alphabet[cc[0]]
+
+    def parse(self, s: str) -> Tuple[str, str]:
+        """
+        Parse the input string into the bare string and check character(s).
+
+        Args:
+            s (str): Input string with check characters.
+
+        Returns:
+            tuple[str, str]: Bare string and check character(s).
+
+        Raises:
+            ValueError: If the check character(s) cannot be found.
+        """
+        char_map = {c: i for i, c in enumerate(self.alphabet)}
+        cc = s[-1]
+        if cc in char_map:
+            return s[:-1], cc
+        raise ValueError("Could not find check character(s)")
+
+    def generate(self, s: str) -> str:
+        """
+        Generate a protected string by appending check character(s).
+
+        Args:
+            s (str): Input string without check characters.
+
+        Returns:
+            str: Protected string with appended check character(s).
+        """
+        return f"{s}{self.compute(s)}"
+
+    def validate(self, s: str) -> bool:
+        """
+        Validate the input string with check character(s).
+
+        Args:
+            s (str): Input string with check characters.
+
+        Returns:
+            bool: True if the string is valid, False otherwise.
+        """
+        bare, cc = self.parse(s)
+        return self.compute(bare) == cc
+
+
+# ISO/IEC 7064 Implementations
+mod11_2 = ISO7064Pure(11, 2, "0123456789X", "EXTRA_CHAR")
+mod37_2 = ISO7064Pure(37, 2, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*", "EXTRA_CHAR")
+mod97_10 = ISO7064Pure(97, 10, "0123456789", "TWO_CCS")
+mod661_26 = ISO7064Pure(661, 26, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "TWO_CCS")
+mod1271_36 = ISO7064Pure(1271, 36, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ", "TWO_CCS")
+
+mod11_10 = ISO7064Hybrid("0123456789")
+mod27_26 = ISO7064Hybrid("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+mod37_36 = ISO7064Hybrid("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+
+if __name__ == "__main__":
+    import stdnum.iso7064.mod_97_10
+
+    # Example usage of mod97_10
+    number = "123456789"
+    print(f"Number: {number}")
+
+    # Appends checksum to the number
+    generated = mod97_10.generate(number)
+    print(f"Generated: {generated}")
+
+    # Computes the check character
+    computed = mod97_10.compute(number)
+    stdnum_check_digit = stdnum.iso7064.mod_97_10.calc_check_digits(number)
+    print(f"Computed Check Character: {computed}  ---  stdnum: {stdnum_check_digit}")
+
+    # Validates the generated number
+    is_valid = mod97_10.validate(generated)
+    is_valid_stdnum = stdnum.iso7064.mod_97_10.is_valid(generated)
+    print(f"Is valid: {is_valid}  ---  stdnum: {is_valid_stdnum}")
+
+    # Parses the generated number
+    bare, cc = mod97_10.parse(generated)
+    print(f"Parsed Bare: {bare}, Check Character: {cc}")

--- a/src/pid4cat_model/iso7064.py
+++ b/src/pid4cat_model/iso7064.py
@@ -262,9 +262,7 @@ mod37_36 = ISO7064Hybrid("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 
 if __name__ == "__main__":
-    import stdnum.iso7064.mod_97_10
-
-    # Example usage of mod97_10
+    # How to use the module? Demo for the mod97_10 algorithm as an example.
     number = "123456789"
     print(f"Number: {number}")
 
@@ -274,13 +272,11 @@ if __name__ == "__main__":
 
     # Computes the check character
     computed = mod97_10.compute(number)
-    stdnum_check_digit = stdnum.iso7064.mod_97_10.calc_check_digits(number)
-    print(f"Computed Check Character: {computed}  ---  stdnum: {stdnum_check_digit}")
+    print(f"Computed Check Character: {computed}")
 
     # Validates the generated number
     is_valid = mod97_10.validate(generated)
-    is_valid_stdnum = stdnum.iso7064.mod_97_10.is_valid(generated)
-    print(f"Is valid: {is_valid}  ---  stdnum: {is_valid_stdnum}")
+    print(f"Is valid: {is_valid}")
 
     # Parses the generated number
     bare, cc = mod97_10.parse(generated)

--- a/src/pid4cat_model/schema/pid4cat_model.yaml
+++ b/src/pid4cat_model/schema/pid4cat_model.yaml
@@ -14,7 +14,7 @@ description: >-
   exception of the resource category, which is a high-level description of
   what is identified by the pid4cat handle, e.g. a sample or a device.
 
-version: "0.0.0"  # Managed by dynamic-versioning. Don't change this line!
+version: "0.3.0.post20.dev0+ef7fe8a"  # Managed by dynamic-versioning. Don't change this line!
 
 todos:
   - none

--- a/src/pid4cat_model/schema/pid4cat_model.yaml
+++ b/src/pid4cat_model/schema/pid4cat_model.yaml
@@ -14,7 +14,7 @@ description: >-
   exception of the resource category, which is a high-level description of
   what is identified by the pid4cat handle, e.g. a sample or a device.
 
-version: "0.3.0.post17.dev0+93e88c2"  # Managed by dynamic-versioning. Don't change this line!
+version: "0.0.0"  # Managed by dynamic-versioning. Don't change this line!
 
 todos:
   - none

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,30 +1,26 @@
-"""Data test."""
-
 import os
 import glob
-import unittest
 
 from linkml_runtime.loaders import yaml_loader, json_loader
-from pid4cat_model.datamodel.pid4cat_model import HandleRecordContainer
+from pid4cat_model.datamodel.pid4cat_model import HandleAPIRecord, HandleRecordContainer
 
 ROOT = os.path.join(os.path.dirname(__file__), "..")
-DATA_DIR = os.path.join(ROOT, "src", "data", "examples", "valid")
-
-EXAMPLE_FILES_YAML = glob.glob(os.path.join(DATA_DIR, "*.yaml"))
-EXAMPLE_FILES_JSON = glob.glob(os.path.join(DATA_DIR, "*.json"))
+DATA_DIR = os.path.join(ROOT, "tests", "data", "valid")
 
 
-class TestData(unittest.TestCase):
-    """Test data and datamodel."""
+def test_yaml_data():
+    """Yaml data test."""
+    for path in glob.glob(os.path.join(DATA_DIR, "HandleAPIRecord*.yaml")):
+        obj = yaml_loader.load(path, target_class=HandleAPIRecord)
+        assert obj
 
-    def test_yaml_data(self):
-        """Yaml data test."""
-        for path in EXAMPLE_FILES_YAML:
-            obj = yaml_loader.load(path, target_class=HandleRecordContainer)
-            assert obj
+    for path in glob.glob(os.path.join(DATA_DIR, "HandleRecordContainer*.yaml")):
+        obj = yaml_loader.load(path, target_class=HandleRecordContainer)
+        assert obj
 
-    def test_json_data(self):
-        """Json data test."""
-        for path in EXAMPLE_FILES_JSON:
-            obj = json_loader.load(path, target_class=HandleRecordContainer)
-            assert obj
+
+def test_json_data():
+    """Json data test."""
+    for path in glob.glob(os.path.join(DATA_DIR, "HandleAPIRecord*.json")):
+        obj = json_loader.load(path, target_class=HandleAPIRecord)
+        assert obj

--- a/tests/test_iso7064.py
+++ b/tests/test_iso7064.py
@@ -1,0 +1,200 @@
+import pytest
+from src.pid4cat_model.iso7064 import (
+    mod11_2,
+    mod37_2,
+    mod97_10,
+    mod661_26,
+    mod1271_36,
+    mod11_10,
+    mod27_26,
+    mod37_36,
+)
+
+# === Tests for pure systems ===
+
+
+@pytest.mark.parametrize(
+    "algo, input_str, expected_output, check_chars",
+    [
+        # mod11_2
+        (mod11_2, "001175717748247", "0011757177482476", "6"),
+        (mod11_2, "747633", "7476336", "6"),
+        (mod11_2, "734404529805608", "7344045298056080", "0"),
+        (mod11_2, "41812925", "418129259", "9"),
+        (mod11_2, "986596515101003", "986596515101003X", "X"),
+        # mod37_2
+        (mod37_2, "J0HO3MGX3F8LKILHHH7", "J0HO3MGX3F8LKILHHH7O", "O"),
+        (mod37_2, "IQ", "IQP", "P"),
+        (mod37_2, "SAH538PZB", "SAH538PZB3", "3"),
+        # mod97_10
+        (mod97_10, "794", "79444", "44"),
+        (mod97_10, "0000", "000001", "01"),
+        (mod97_10, "00001055949422872", "0000105594942287263", "63"),
+        # mod661_26
+        (mod661_26, "BAISDLAFK", "BAISDLAFKBM", "BM"),
+        (mod661_26, "GCJFBCIOJTLVO", "GCJFBCIOJTLVOUR", "UR"),
+        # mod1271_36
+        (mod1271_36, "ISO 79", "ISO 793W", "3W"),
+        (mod1271_36, "XVMZN7CD83796I1Q65VVZA", "XVMZN7CD83796I1Q65VVZA0J", "0J"),
+    ],
+)
+def test_pure_systems_valid(algo, input_str, expected_output, check_chars):
+    """
+    Test ISO 7064 pure systems with valid data.
+    """
+    assert hasattr(algo, "flavor")
+    # Test generate
+    generated = algo.generate(input_str)
+    assert generated == expected_output, f"Failed to generate for {algo.name}"
+
+    # Test validate
+    assert algo.validate(expected_output), f"Failed to validate for {algo.name}"
+
+    # Test parse
+    bare, cc = algo.parse(expected_output)
+    assert bare == input_str, f"Failed to parse bare string for {algo.name}"
+    assert cc == check_chars, f"Failed to parse check character for {algo.name}"
+    assert algo.compute(input_str) == cc, (
+        f"Failed to compute check character for {algo.name}"
+    )
+
+
+@pytest.mark.parametrize(
+    "algo, input_str, invalid_output, invalid_check_chars",
+    [
+        # mod11_2
+        (mod11_2, "001175717748247", "0011757177482477", "7"),
+        (mod11_2, "97", "97X", "X"),
+        # mod37_2
+        (mod37_2, "TZ25NP", "TZ25NP5", "5"),
+        (mod37_2, "R1WDRN9EQ", "R1WDRN9EQK", "K"),
+        # mod97_10
+        (mod97_10, "794", "79445", "45"),
+        (mod97_10, "5489482033978", "548948203397832", "32"),
+        # mod661_26
+        (mod661_26, "BAISDLAFK", "BAISDLAFKAB", "AB"),
+        (mod661_26, "GCJFBCIOJTLVO", "GCJFBCIOJTLVOBI", "BI"),
+        # mod1271_36
+        (mod1271_36, "ISO 79", "ISO 7912", "12"),
+        (mod1271_36, "ERMSIN9W42JD", "ERMSIN9W42JD98", "98"),
+    ],
+)
+def test_pure_systems_invalid(algo, input_str, invalid_output, invalid_check_chars):
+    """
+    Test ISO 7064 pure systems with invalid data.
+    """
+    assert hasattr(algo, "flavor")
+    # Test generate
+    generated = algo.generate(input_str)
+    assert generated != invalid_output
+
+    # Test validate
+    assert not algo.validate(invalid_output)
+
+    # Test parse (the invalid output should still be parsed correctly)
+    bare, cc = algo.parse(invalid_output)
+    assert bare == input_str
+    assert cc == invalid_check_chars
+    assert algo.compute(input_str) != cc
+
+
+# === Tests for hybrid systems ===
+
+
+@pytest.mark.parametrize(
+    "algo, input_str, expected_output, check_chars",
+    [
+        # mod11_10
+        (mod11_10, "0794", "07945", "5"),
+        (mod11_10, "003", "0032", "2"),
+        (mod11_10, "86662765", "866627650", "0"),
+        # mod27_26
+        (mod27_26, "JEJLMGJ", "JEJLMGJS", "S"),
+        (mod27_26, "MUFEMSTCATLIT", "MUFEMSTCATLITB", "B"),
+        # mod37_36
+        (mod37_36, "TBR", "TBR1", "1"),
+        (mod37_36, "B3739U6CR", "B3739U6CRK", "K"),
+    ],
+)
+def test_hybrid_systems_valid(algo, input_str, expected_output, check_chars):
+    """
+    Test ISO 7064 hybrid systems with valid data.
+    """
+    assert not hasattr(algo, "flavor")
+
+    generated = algo.generate(input_str)
+    assert generated == expected_output, f"Failed to generate for {algo.name}"
+
+    # Test validate
+    assert algo.validate(expected_output), f"Failed to validate for {algo.name}"
+
+    # Test parse
+    bare, cc = algo.parse(expected_output)
+    assert bare == input_str, f"Failed to parse bare string for {algo.name}"
+    assert cc == check_chars, f"Failed to parse check character for {algo.name}"
+    assert algo.compute(input_str) == cc, (
+        f"Failed to compute check character for {algo.name}"
+    )
+
+
+@pytest.mark.parametrize(
+    "algo, input_str, invalid_output, invalid_check_chars",
+    [
+        # mod11_10
+        (mod11_10, "82380342642", "823803426424", "4"),
+        (mod11_10, "04088080371", "040880803711", "1"),
+        # mod27_26
+        (mod27_26, "JEJLMGJ", "JEJLMGJX", "X"),
+        (mod27_26, "MUFEMSTCATLIT", "MUFEMSTCATLITH", "H"),
+        # mod37_36
+        (mod37_36, "MR", "MRZ", "Z"),
+        (mod37_36, "4KWL6BPN", "4KWL6BPNH", "H"),
+    ],
+)
+def test_hybrid_systems_invalid(algo, input_str, invalid_output, invalid_check_chars):
+    """
+    Test ISO 7064 hybrid systems with invalid data.
+    """
+    assert not hasattr(algo, "flavor")
+
+    generated = algo.generate(input_str)
+    assert generated != invalid_output
+
+    # Test validate
+    assert not algo.validate(invalid_output)
+
+    # Test parse (the invalid output should still be parsed correctly)
+    bare, cc = algo.parse(invalid_output)
+    assert bare == input_str
+    assert cc == invalid_check_chars
+    assert algo.compute(input_str) != cc
+
+
+# === Tests for exceptions ===
+
+
+def test_pure_systems_invalid_chars():
+    """
+    Test ISO 7064 systems with invalid check char.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        bare, cc = mod11_2.parse("AB123ß")
+    assert "Could not find check character(s)" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        bare, cc = mod11_10.parse("AB123ß")
+    assert "Could not find check character(s)" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("algo", [mod11_2, mod11_10])
+def test_pure_systems_invalid_numbers(algo):
+    """
+    Test ISO 7064 hybrid systems with invalid input.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        _ = algo.compute_from_num_vals([])
+    assert "String to be protected is empty" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        _ = algo.compute_from_num_vals([100])
+    assert "Invalid numerical value detected" in str(excinfo.value)

--- a/uv.lock
+++ b/uv.lock
@@ -319,6 +319,56 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/4f/2251e65033ed2ce1e68f00f91a0294e0f80c80ae8c3ebbe2f12828c4cd53/coverage-7.8.0.tar.gz", hash = "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501", size = 811872 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/77/074d201adb8383addae5784cb8e2dac60bb62bfdf28b2b10f3a3af2fda47/coverage-7.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27", size = 211493 },
+    { url = "https://files.pythonhosted.org/packages/a9/89/7a8efe585750fe59b48d09f871f0e0c028a7b10722b2172dfe021fa2fdd4/coverage-7.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea", size = 211921 },
+    { url = "https://files.pythonhosted.org/packages/e9/ef/96a90c31d08a3f40c49dbe897df4f1fd51fb6583821a1a1c5ee30cc8f680/coverage-7.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7", size = 244556 },
+    { url = "https://files.pythonhosted.org/packages/89/97/dcd5c2ce72cee9d7b0ee8c89162c24972fb987a111b92d1a3d1d19100c61/coverage-7.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040", size = 242245 },
+    { url = "https://files.pythonhosted.org/packages/b2/7b/b63cbb44096141ed435843bbb251558c8e05cc835c8da31ca6ffb26d44c0/coverage-7.8.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543", size = 244032 },
+    { url = "https://files.pythonhosted.org/packages/97/e3/7fa8c2c00a1ef530c2a42fa5df25a6971391f92739d83d67a4ee6dcf7a02/coverage-7.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2", size = 243679 },
+    { url = "https://files.pythonhosted.org/packages/4f/b3/e0a59d8df9150c8a0c0841d55d6568f0a9195692136c44f3d21f1842c8f6/coverage-7.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318", size = 241852 },
+    { url = "https://files.pythonhosted.org/packages/9b/82/db347ccd57bcef150c173df2ade97976a8367a3be7160e303e43dd0c795f/coverage-7.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9", size = 242389 },
+    { url = "https://files.pythonhosted.org/packages/21/f6/3f7d7879ceb03923195d9ff294456241ed05815281f5254bc16ef71d6a20/coverage-7.8.0-cp311-cp311-win32.whl", hash = "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c", size = 213997 },
+    { url = "https://files.pythonhosted.org/packages/28/87/021189643e18ecf045dbe1e2071b2747901f229df302de01c998eeadf146/coverage-7.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78", size = 214911 },
+    { url = "https://files.pythonhosted.org/packages/aa/12/4792669473297f7973518bec373a955e267deb4339286f882439b8535b39/coverage-7.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc", size = 211684 },
+    { url = "https://files.pythonhosted.org/packages/be/e1/2a4ec273894000ebedd789e8f2fc3813fcaf486074f87fd1c5b2cb1c0a2b/coverage-7.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6", size = 211935 },
+    { url = "https://files.pythonhosted.org/packages/f8/3a/7b14f6e4372786709a361729164125f6b7caf4024ce02e596c4a69bccb89/coverage-7.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d", size = 245994 },
+    { url = "https://files.pythonhosted.org/packages/54/80/039cc7f1f81dcbd01ea796d36d3797e60c106077e31fd1f526b85337d6a1/coverage-7.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05", size = 242885 },
+    { url = "https://files.pythonhosted.org/packages/10/e0/dc8355f992b6cc2f9dcd5ef6242b62a3f73264893bc09fbb08bfcab18eb4/coverage-7.8.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a", size = 245142 },
+    { url = "https://files.pythonhosted.org/packages/43/1b/33e313b22cf50f652becb94c6e7dae25d8f02e52e44db37a82de9ac357e8/coverage-7.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6", size = 244906 },
+    { url = "https://files.pythonhosted.org/packages/05/08/c0a8048e942e7f918764ccc99503e2bccffba1c42568693ce6955860365e/coverage-7.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47", size = 243124 },
+    { url = "https://files.pythonhosted.org/packages/5b/62/ea625b30623083c2aad645c9a6288ad9fc83d570f9adb913a2abdba562dd/coverage-7.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe", size = 244317 },
+    { url = "https://files.pythonhosted.org/packages/62/cb/3871f13ee1130a6c8f020e2f71d9ed269e1e2124aa3374d2180ee451cee9/coverage-7.8.0-cp312-cp312-win32.whl", hash = "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545", size = 214170 },
+    { url = "https://files.pythonhosted.org/packages/88/26/69fe1193ab0bfa1eb7a7c0149a066123611baba029ebb448500abd8143f9/coverage-7.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b", size = 214969 },
+    { url = "https://files.pythonhosted.org/packages/f3/21/87e9b97b568e223f3438d93072479c2f36cc9b3f6b9f7094b9d50232acc0/coverage-7.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ac46d0c2dd5820ce93943a501ac5f6548ea81594777ca585bf002aa8854cacd", size = 211708 },
+    { url = "https://files.pythonhosted.org/packages/75/be/882d08b28a0d19c9c4c2e8a1c6ebe1f79c9c839eb46d4fca3bd3b34562b9/coverage-7.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:771eb7587a0563ca5bb6f622b9ed7f9d07bd08900f7589b4febff05f469bea00", size = 211981 },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/ce99612ebd58082fbe3f8c66f6d8d5694976c76a0d474503fa70633ec77f/coverage-7.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42421e04069fb2cbcbca5a696c4050b84a43b05392679d4068acbe65449b5c64", size = 245495 },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/6115abe97df98db6b2bd76aae395fcc941d039a7acd25f741312ced9a78f/coverage-7.8.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:554fec1199d93ab30adaa751db68acec2b41c5602ac944bb19187cb9a41a8067", size = 242538 },
+    { url = "https://files.pythonhosted.org/packages/cb/74/2f8cc196643b15bc096d60e073691dadb3dca48418f08bc78dd6e899383e/coverage-7.8.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aaeb00761f985007b38cf463b1d160a14a22c34eb3f6a39d9ad6fc27cb73008", size = 244561 },
+    { url = "https://files.pythonhosted.org/packages/22/70/c10c77cd77970ac965734fe3419f2c98665f6e982744a9bfb0e749d298f4/coverage-7.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:581a40c7b94921fffd6457ffe532259813fc68eb2bdda60fa8cc343414ce3733", size = 244633 },
+    { url = "https://files.pythonhosted.org/packages/38/5a/4f7569d946a07c952688debee18c2bb9ab24f88027e3d71fd25dbc2f9dca/coverage-7.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f319bae0321bc838e205bf9e5bc28f0a3165f30c203b610f17ab5552cff90323", size = 242712 },
+    { url = "https://files.pythonhosted.org/packages/bb/a1/03a43b33f50475a632a91ea8c127f7e35e53786dbe6781c25f19fd5a65f8/coverage-7.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04bfec25a8ef1c5f41f5e7e5c842f6b615599ca8ba8391ec33a9290d9d2db3a3", size = 244000 },
+    { url = "https://files.pythonhosted.org/packages/6a/89/ab6c43b1788a3128e4d1b7b54214548dcad75a621f9d277b14d16a80d8a1/coverage-7.8.0-cp313-cp313-win32.whl", hash = "sha256:dd19608788b50eed889e13a5d71d832edc34fc9dfce606f66e8f9f917eef910d", size = 214195 },
+    { url = "https://files.pythonhosted.org/packages/12/12/6bf5f9a8b063d116bac536a7fb594fc35cb04981654cccb4bbfea5dcdfa0/coverage-7.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:a9abbccd778d98e9c7e85038e35e91e67f5b520776781d9a1e2ee9d400869487", size = 214998 },
+    { url = "https://files.pythonhosted.org/packages/2a/e6/1e9df74ef7a1c983a9c7443dac8aac37a46f1939ae3499424622e72a6f78/coverage-7.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:18c5ae6d061ad5b3e7eef4363fb27a0576012a7447af48be6c75b88494c6cf25", size = 212541 },
+    { url = "https://files.pythonhosted.org/packages/04/51/c32174edb7ee49744e2e81c4b1414ac9df3dacfcb5b5f273b7f285ad43f6/coverage-7.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95aa6ae391a22bbbce1b77ddac846c98c5473de0372ba5c463480043a07bff42", size = 212767 },
+    { url = "https://files.pythonhosted.org/packages/e9/8f/f454cbdb5212f13f29d4a7983db69169f1937e869a5142bce983ded52162/coverage-7.8.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e013b07ba1c748dacc2a80e69a46286ff145935f260eb8c72df7185bf048f502", size = 256997 },
+    { url = "https://files.pythonhosted.org/packages/e6/74/2bf9e78b321216d6ee90a81e5c22f912fc428442c830c4077b4a071db66f/coverage-7.8.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d766a4f0e5aa1ba056ec3496243150698dc0481902e2b8559314368717be82b1", size = 252708 },
+    { url = "https://files.pythonhosted.org/packages/92/4d/50d7eb1e9a6062bee6e2f92e78b0998848a972e9afad349b6cdde6fa9e32/coverage-7.8.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad80e6b4a0c3cb6f10f29ae4c60e991f424e6b14219d46f1e7d442b938ee68a4", size = 255046 },
+    { url = "https://files.pythonhosted.org/packages/40/9e/71fb4e7402a07c4198ab44fc564d09d7d0ffca46a9fb7b0a7b929e7641bd/coverage-7.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b87eb6fc9e1bb8f98892a2458781348fa37e6925f35bb6ceb9d4afd54ba36c73", size = 256139 },
+    { url = "https://files.pythonhosted.org/packages/49/1a/78d37f7a42b5beff027e807c2843185961fdae7fe23aad5a4837c93f9d25/coverage-7.8.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:d1ba00ae33be84066cfbe7361d4e04dec78445b2b88bdb734d0d1cbab916025a", size = 254307 },
+    { url = "https://files.pythonhosted.org/packages/58/e9/8fb8e0ff6bef5e170ee19d59ca694f9001b2ec085dc99b4f65c128bb3f9a/coverage-7.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883", size = 255116 },
+    { url = "https://files.pythonhosted.org/packages/56/b0/d968ecdbe6fe0a863de7169bbe9e8a476868959f3af24981f6a10d2b6924/coverage-7.8.0-cp313-cp313t-win32.whl", hash = "sha256:379fe315e206b14e21db5240f89dc0774bdd3e25c3c58c2c733c99eca96f1ada", size = 214909 },
+    { url = "https://files.pythonhosted.org/packages/87/e9/d6b7ef9fecf42dfb418d93544af47c940aa83056c49e6021a564aafbc91f/coverage-7.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e4b6b87bb0c846a9315e3ab4be2d52fac905100565f4b92f02c445c8799e257", size = 216068 },
+    { url = "https://files.pythonhosted.org/packages/c4/f1/1da77bb4c920aa30e82fa9b6ea065da3467977c2e5e032e38e66f1c57ffd/coverage-7.8.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd", size = 203443 },
+    { url = "https://files.pythonhosted.org/packages/59/f1/4da7717f0063a222db253e7121bd6a56f6fb1ba439dcc36659088793347c/coverage-7.8.0-py3-none-any.whl", hash = "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7", size = 203435 },
+]
+
+[[package]]
 name = "curies"
 version = "0.10.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1529,12 +1579,14 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage" },
     { name = "jupyter" },
     { name = "linkml" },
     { name = "mike" },
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mknotebooks" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1545,12 +1597,14 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage", specifier = ">=7.8.0" },
     { name = "jupyter", specifier = ">=1.0.0" },
     { name = "linkml", specifier = ">=1.3.5" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs-material", specifier = ">=8.2.8" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.1" },
     { name = "mknotebooks", specifier = ">=0.8.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
- adds a module for ISO/IEC7064 checksum algorithms including tests (100% coverage).
- adds coverage and pytest as dev-dependencies
- adds a (local) just recipe `just coverage`
- fixes wrong data dir in `test_data.py` which resulted in no files being tested as revealed by coverage data
- converts `test_data.py` from unittest to pytest

Closes #117