### PR TITLE
Stop truncating descriptions in schema docs

### DIFF
--- a/config.public.mk
+++ b/config.public.mk
@@ -17,7 +17,7 @@ LINKML_SCHEMA_SOURCE_DIR="src/pid4cat_model/schema"
 LINKML_GENERATORS_CONFIG_YAML=config.yaml
 
 ## pass args if gendoc ignores config.yaml (i.e. --no-mergeimports)
-LINKML_GENERATORS_DOC_ARGS="--hierarchical-class-view --subfolder-type-separation --index-name overview"
+LINKML_GENERATORS_DOC_ARGS="--truncate-descriptions False --hierarchical-class-view --subfolder-type-separation --index-name overview"
 
 ## pass args to workaround genowl rdfs config bug (linkml#1453)
 ##   (i.e. --no-type-objects --no-metaclasses --metadata-profile rdfs)


### PR DESCRIPTION
LinkML release 1.9.2 made it easier to avoid truncating of the descriptions of the model elements in the schema documentation.
This PR switches to generating full descriptions which is much more valuable than saving a few lines on a webpage.