### PR TITLE
Small fix of markup in index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: **pid4cat Documentation**
+title: pid4cat Documentation
 ---
 
 ![pid4cat logo](images/logo-with-text.svg#only-light)


### PR DESCRIPTION
The index-page of v0.4.1 shows some html-style tags which should not be visible.

Styling the title is obviously not supported. So this PR removes it.